### PR TITLE
Search by transcriber

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6.2
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code

--- a/assets/js/lib/tracklist.ts
+++ b/assets/js/lib/tracklist.ts
@@ -6,6 +6,7 @@ export interface SongIndexEntry {
     id: number;
     title: string;
     artist: string;
+    transcriber: string;
     length: number;
     cover: string;
     duet?: string[];
@@ -63,7 +64,7 @@ export async function getSongData(search?: string): Promise<SongIndexEntry[]> {
     if (search === '') {
         return _songData;
     }
-    return _songData.filter((x) => x.title.toLowerCase().includes(search) || x.artist.toLowerCase().includes(search));
+    return _songData.filter((x) => x.title.toLowerCase().includes(search) || x.artist.toLowerCase().includes(search) || x.transcriber.toLowerCase().includes(search));
 }
 
 export async function getSongMap(): Promise<SongIndexMap> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: postgres
     volumes:
     - ./postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgres
   redis:
     image: redis
   web:

--- a/karaoke/views.py
+++ b/karaoke/views.py
@@ -71,6 +71,7 @@ def track_listing(request):
             'id': song.id,
             'title': song.title,
             'artist': song.artist,
+            'transcriber': song.transcriber,
             'length': song.length,
             'cover': song.cover_image,
         }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "uglifyjs-webpack-plugin": "^1.1.6"
   },
   "engines": {
-    "node": "9.4.0",
-    "yarn": "1.3.2"
+    "node": "13.11.0",
+    "yarn": "1.22.4"
   }
 }

--- a/ponytone/settings.py
+++ b/ponytone/settings.py
@@ -81,7 +81,7 @@ WSGI_APPLICATION = 'ponytone.wsgi.application'
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 DATABASES = {
-    'default': dj_database_url.config(default='postgres://postgres@db:5432/postgres', conn_max_age=600)
+    'default': dj_database_url.config(default='postgres://postgres:postgres@db:5432/postgres', conn_max_age=600)
 }
 
 # Password validation


### PR DESCRIPTION
As someone that transcriber songs, it is frustrating when someone asks "Well, what songs did you make then" and not just being able to search for it. This will (just like in USDX) lead to some extra search results for a couple of generic queries (eg "rainbow" "derpy" (which also match "rainbowderpy")) but usually those people are just browsing songs anyway, so a few extra results won't really matter.

I've seen some people use "eque" as a shorthand for "equestria girls" which will also start matching "barbeque" with this change, but if you want EQG searching for "equestria" isn't the way to do it anyway lol; "girls" is much better.

NB: the first commit 355cc05 just makes it buildable again (at least on my machine) because of postgres updates and python:3 matching something that won't compile. The second commit d015da1 is the one with the actual changes. Feel free to cherry pick things.