### PR TITLE
Change PeerConnection close to emit a 'close' event.

### DIFF
--- a/assets/js/lib/party/p2p.ts
+++ b/assets/js/lib/party/p2p.ts
@@ -42,6 +42,7 @@ export class PeerConnection extends EventEmitter {
     close(): void {
         if (this.connection) {
             this.connection.close();
+            this.emit("close");
         }
     }
 


### PR DESCRIPTION
This change fixes Katharine/ponytone#22.

I had to apply the changes from @barbeque-squared build-fixes branch before the "docker-compose" and "yarn build" commands listed in the README would run. I have excluded these as they weren't included in Katharine/ponytone#21.